### PR TITLE
adjust string to use template block, and reduce use of escapes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = Parsick;
 
 Parsick.prototype.parse = function (type, source, fields) {
   if(arguments.length < 3) {
-    throw new TypeError('You need send \'type\', \'source\' and \'fields\' to parse your data');
+    throw new TypeError(`You need send 'type', 'source' and 'fields' to parse your data`);
   }
 
   if(!_.has(this.adapters, type)) {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = Parsick;
 
 Parsick.prototype.parse = function (type, source, fields) {
   if(arguments.length < 3) {
-    throw new TypeError('You need send \'type\', \'source\' and \'fields\' to parse your data');
+    throw new TypeError(`You need send 'type', 'source' and 'fields' to parse your data`);
   }
 
   if(!_.has(this.adapters, type)) {
@@ -26,7 +26,7 @@ function loadAdapters () {
   let adapters = {};
   loader('adapters').forEach((adapter) => {
     let name = adapter.name.toLowerCase();
-    adapters[name] = adapter.File;  
+    adapters[name] = adapter.File;
   });
   return adapters;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -31,12 +31,12 @@ describe('Parsick module', () => {
 
     it('should have json parser', () => {
       expect(parsick.adapters).to.have.property('json');
-      expect(parsick.adapters.json).to.be.a('function'); 
+      expect(parsick.adapters.json).to.be.a('function');
     });
 
     it('should have xml parser', () => {
       expect(parsick.adapters).to.have.property('xml');
-      expect(parsick.adapters.xml).to.be.a('function'); 
+      expect(parsick.adapters.xml).to.be.a('function');
     });
   });
 
@@ -45,7 +45,7 @@ describe('Parsick module', () => {
       it('when no arguments are passed', () => {
         let fn = () => { parsick.parse() };
         expect(fn).to.be.throw(TypeError);
-        expect(fn).to.be.throw('You need send \'type\', \'source\' and \'fields\' to parse your data');
+        expect(fn).to.be.throw(`You need send 'type', 'source' and 'fields' to parse your data`);
       });
 
       it('when type has a invalid type', () => {


### PR DESCRIPTION
template blocks allow less escapes

``` js
let str = `lero lero 'lero'`
```

instead

``` js
let str = 'lero lero \'lero\'';
```

to allow escape variables, like below:

``` js
let name = 'Wo lo loo'
let str = `hello ${name}`;
```
